### PR TITLE
feat: add task level monitoring per job

### DIFF
--- a/canary/cmd/canary_producer.py
+++ b/canary/cmd/canary_producer.py
@@ -20,6 +20,9 @@ def run():
         cfg.StrOpt('path',
                    default='/taskflow/jobs',
                    help='taskflow path to track'),
+        cfg.StrOpt('logbook_path',
+                   default='/taskflow',
+                   help='logbook path to track'),
         cfg.StrOpt('persistence',
                    default='zookeeper',
                    help='persistence backend driver'),
@@ -45,7 +48,8 @@ def run():
         'conf' : {
             'path' : conf['canary'].path,
             'hosts': conf['canary'].zookeeper_host
-        }
+        },
+        'logbook_path': conf['canary'].logbook_path,
     }
 
     LOG.info("Posting job to Zookeeper Jobboard")

--- a/canary/model/__init__.py
+++ b/canary/model/__init__.py
@@ -1,18 +1,49 @@
 import json
 
+from taskflow.persistence.backends.impl_zookeeper import ZkBackend
 from taskflow.jobs.backends.impl_zookeeper import ZookeeperJobBoard
+
 
 class JobBoard(object):
 
-    def __init__(self, name, conf, persistence):
+    def __init__(self, name, conf, persistence, logbook_path):
         self.name = name
         self.conf = conf
         self.persistence = persistence
+        self.logbook_path = logbook_path
 
         self.board = ZookeeperJobBoard(name=self.name,
                                        conf=self.conf,
                                        persistence=self.persistence)
         self.board.connect()
+
+
+    def get_flow_status(self, book_uuid):
+
+        log_book_conf = self.conf.copy()
+        log_book_conf['path'] = self.logbook_path
+        backend = ZkBackend(log_book_conf)
+        connection = backend.get_connection()
+        log_book = connection.get_logbook(book_uuid)
+        current_flow_status = {}
+        complete_task_status = []
+        current_task_status = {}
+        for (uuid, flow) in log_book._flowdetails_by_id.items():
+
+            flow_details = flow.to_dict()
+            del flow_details['name']
+            current_flow_status[flow.name] = flow_details
+            for (uuid, task) in flow._atomdetails_by_id.items():
+                task_details = task.to_dict()
+                del task_details['name']
+                current_task_status[task.name.replace('.','-')] = \
+                    task_details
+            complete_task_status.append(current_task_status)
+
+            current_flow_status[flow.name]['tasks'] = complete_task_status
+
+        backend.close()
+        return current_flow_status
 
     def get_all_jobs(self, serializable=False):
 
@@ -25,12 +56,14 @@ class JobBoard(object):
             json_list = []
             for job in jobs_iter:
                 board = job.board
+                current_flow_status = self.get_flow_status(job._book_data['uuid'])
                 owner = board.find_owner(job)
                 status = job.state
                 job_dict = job.__dict__
                 job_dict['_created_on'] = job_dict['_created_on'].isoformat()
                 job_dict['status'] = status
                 job_dict['owner'] = owner
+                job_dict['flow_status'] = current_flow_status
                 del job_dict['_client']
                 del job_dict['_board']
                 json_list.append(job_dict)

--- a/canary/tasks/flows/store_details.py
+++ b/canary/tasks/flows/store_details.py
@@ -69,8 +69,11 @@ class GenerateTaskflowInformation(task.Task):
 
     default_provides = 'job_details_tuple'
 
-    def execute(self, name, path, conf, persistence):
-        jb = JobBoard(name=name,conf=conf,persistence=persistence)
+    def execute(self, name, path, conf, persistence, logbook_path):
+        jb = JobBoard(name=name,
+                      conf=conf,
+                      persistence=persistence,
+                      logbook_path=logbook_path)
         job_details = jb.get_all_jobs(serializable=True)
         job_count = jb.board.job_count
         job_details_tuple = (job_details, path, job_count)

--- a/etc/canary.conf
+++ b/etc/canary.conf
@@ -22,6 +22,7 @@ log_config_append = /etc/canary/logging.conf
 host = 127.0.0.1
 port = 8888
 name = my_jobs
+logbook_path = /taskflow
 path = /taskflow/jobs/my_jobs
 persistence = zookeeper
 interval = 7200


### PR DESCRIPTION
Example:
```json
flow_status" : {
                "myawesomeservice-26f12a33-593e-40db-809d-7838df179bf0" : {
                    "state" : "RUNNING",
                    "tasks" : [
                        {
                            "myawesome_workers.dosomeTask" : {
                                "version" : "1.0",
                                "intention" : "EXECUTE",
                                "results" : null,
                                "failure" : null,
                                "state" : "RUNNING",
                                "meta" : {
                                    "progress" : 0
                                },
                                "uuid" : "7f6ce67a-ac91-478e-bd90-fe4b36c84598"
                            },
                            "_TaskFlow_INJECTOR" : {
                                "version" : null,
                                "intention" : "EXECUTE",
                                "results" : {
                                    "awesome" : "sauce"                             },
                                "failure" : null,
                                "state" : "SUCCESS",
                                "meta" : {

                                },
                                "uuid" : "a0fea8b4-8156-47ab-a929-d8acb1a7a56c"
                            }
                        }
                    ],
                    "meta" : {
                        "factory" : {
                            "args" : [ ],
                            "name" : "myawesome_workers.my_awesome_service,
                            "kwargs" : {

                            }
                        }
                    },
                    "uuid" : "85d84147-f14e-4ea8-8dd4-a8aa09279437"
                }
```